### PR TITLE
fix: resolve authentication errors in technical module API routes

### DIFF
--- a/apps/frontend/app/(authenticated)/technical/products/page.tsx
+++ b/apps/frontend/app/(authenticated)/technical/products/page.tsx
@@ -75,6 +75,7 @@ export default function ProductsPage() {
   const [products, setProducts] = useState<Product[]>([])
   const [loading, setLoading] = useState(true)
   const [searchTerm, setSearchTerm] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
   const [typeFilter, setTypeFilter] = useState<string>('all')
   const [statusFilter, setStatusFilter] = useState<string>('all')
   const [showCreateModal, setShowCreateModal] = useState(false)
@@ -99,7 +100,7 @@ export default function ProductsPage() {
       setLoading(true)
 
       const params = new URLSearchParams()
-      if (searchTerm) params.append('search', searchTerm)
+      if (debouncedSearch) params.append('search', debouncedSearch)
       if (typeFilter !== 'all') params.append('type', typeFilter)
       if (statusFilter !== 'all') params.append('status', statusFilter)
       params.append('sort', sortBy)
@@ -129,20 +130,20 @@ export default function ProductsPage() {
     }
   }
 
-  // Fetch on filter/sort/page changes
-  useEffect(() => {
-    fetchProducts()
-  }, [typeFilter, statusFilter, sortBy, sortDirection, page])
-
-  // Debounced search
+  // Debounce search input
   useEffect(() => {
     const timer = setTimeout(() => {
+      setDebouncedSearch(searchTerm)
       setPage(1) // Reset to first page on search
-      fetchProducts()
     }, 300)
 
     return () => clearTimeout(timer)
   }, [searchTerm])
+
+  // Fetch on filter/sort/page/search changes
+  useEffect(() => {
+    fetchProducts()
+  }, [typeFilter, statusFilter, sortBy, sortDirection, page, debouncedSearch])
 
   // Handlers
   const handleEdit = (product: Product) => {

--- a/apps/frontend/app/api/technical/products/[id]/allergens/route.ts
+++ b/apps/frontend/app/api/technical/products/[id]/allergens/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { createServerSupabaseAdmin } from '@/lib/supabase/server'
+import { createServerSupabase } from '@/lib/supabase/server'
 import { allergenAssignmentSchema } from '@/lib/validation/product-schemas'
 import { ZodError } from 'zod'
 
@@ -15,20 +15,34 @@ type RouteContext = {
 // PUT /api/technical/products/[id]/allergens - Update product allergens
 export async function PUT(req: NextRequest, context: RouteContext) {
   try {
-    const supabase = createServerSupabaseAdmin()
+    const supabase = await createServerSupabase()
     const { id } = await context.params
 
-    // Get user from session
-    const { data: { user }, error: authError } = await supabase.auth.getUser()
+    // Check authentication
+    const { data: { session }, error: authError } = await supabase.auth.getSession()
 
-    if (authError || !user) {
+    if (authError || !session) {
       return NextResponse.json(
         { error: 'Unauthorized' },
         { status: 401 }
       )
     }
 
-    const orgId = user.user_metadata.org_id
+    // Get current user to get org_id
+    const { data: currentUser, error: userError } = await supabase
+      .from('users')
+      .select('org_id')
+      .eq('id', session.user.id)
+      .single()
+
+    if (userError || !currentUser) {
+      return NextResponse.json(
+        { error: 'User not found' },
+        { status: 404 }
+      )
+    }
+
+    const orgId = currentUser.org_id
 
     // Verify product exists
     const { data: product } = await supabase
@@ -90,14 +104,14 @@ export async function PUT(req: NextRequest, context: RouteContext) {
         allergen_id: allergenId,
         relation_type: 'contains',
         org_id: orgId,
-        created_by: user.id
+        created_by: session.user.id
       })),
       ...validated.may_contain.map(allergenId => ({
         product_id: id,
         allergen_id: allergenId,
         relation_type: 'may_contain',
         org_id: orgId,
-        created_by: user.id
+        created_by: session.user.id
       }))
     ]
 

--- a/apps/frontend/app/api/technical/products/[id]/history/route.ts
+++ b/apps/frontend/app/api/technical/products/[id]/history/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { createServerSupabaseAdmin } from '@/lib/supabase/server'
+import { createServerSupabase } from '@/lib/supabase/server'
 import { z } from 'zod'
 
 type RouteContext = {
@@ -19,20 +19,34 @@ const historyQuerySchema = z.object({
 // GET /api/technical/products/[id]/history - Get version history
 export async function GET(req: NextRequest, context: RouteContext) {
   try {
-    const supabase = createServerSupabaseAdmin()
+    const supabase = await createServerSupabase()
     const { id } = await context.params
 
-    // Get user from session
-    const { data: { user }, error: authError } = await supabase.auth.getUser()
+    // Check authentication
+    const { data: { session }, error: authError } = await supabase.auth.getSession()
 
-    if (authError || !user) {
+    if (authError || !session) {
       return NextResponse.json(
         { error: 'Unauthorized' },
         { status: 401 }
       )
     }
 
-    const orgId = user.user_metadata.org_id
+    // Get current user to get org_id
+    const { data: currentUser, error: userError } = await supabase
+      .from('users')
+      .select('org_id')
+      .eq('id', session.user.id)
+      .single()
+
+    if (userError || !currentUser) {
+      return NextResponse.json(
+        { error: 'User not found' },
+        { status: 404 }
+      )
+    }
+
+    const orgId = currentUser.org_id
 
     // Verify product exists and belongs to org
     const { data: product } = await supabase


### PR DESCRIPTION
Replace createServerSupabaseAdmin() with createServerSupabase() in all technical API routes. The admin client doesn't have access to user session cookies, causing "Unauthorized" errors.

Changes:
- Use async createServerSupabase() with session cookies instead of admin client in all technical/* API routes
- Use getSession() instead of getUser() for authentication
- Fetch org_id from users table instead of user.user_metadata
- Fix search debouncing in products page to prevent double fetches
- Use debouncedSearch state for cleaner search handling

Affected routes:
- /api/technical/products (GET, POST)
- /api/technical/products/[id] (GET, PUT, DELETE)
- /api/technical/products/[id]/allergens (PUT)
- /api/technical/products/[id]/history (GET)
- /api/technical/products/[id]/history/compare (GET)
- /api/technical/product-types (GET, POST)
- /api/technical/product-types/[id] (GET, PUT, DELETE)
- /api/technical/settings (GET, PUT)

# Podsumowanie

- Krótki opis celu i kontekstu zmian.

## Typ zmiany

- [ ] feat
- [ ] fix
- [ ] chore
- [ ] docs
- [ ] test

## Powiązane zagadnienia

- Closes #
- Relates to #

## Zakres i wpływ

- Co zostało zmienione (moduły, endpointy, komponenty).
- Potencjalny wpływ na istniejące funkcje i dane.

## Zmiany (skrót)

-
-

## Zrzuty ekranu / wideo (UI)

- Jeśli dotyczy, dołącz materiały poglądowe.

## Jak testować (lokalnie)

```bash
pnpm install
pnpm type-check
pnpm test
# opcjonalnie
pnpm test:e2e:critical
```

## BMAD Quality Gates — Minimal Pass

- QG‑AUDIT (docs/12_NIESPOJNOSCI_FIX_CHECKLIST.md)
  - [ ] P0 zidentyfikowane i rozwiązane lub N/A z uzasadnieniem
- QG‑DB (docs/09_DATABASE_SCHEMA.md)
  - [ ] Migracje dodane i przetestowane
  - [ ] Dokumentacja schematu zaktualizowana
  - [ ] PK/FK/indeksy oraz RLS zgodne z ustaleniami
- QG‑UI (docs/03_APP_GUIDE.md)
  - [ ] Lint i type‑check bez ostrzeżeń
  - [ ] Brak błędów w konsoli przeglądarki
  - [ ] Krytyczne E2E zielone (apps/frontend/e2e/…)
  - [ ] Kontrakt typów API↔UI zgodny
- QG‑PROC (docs/02_BUSINESS_PROCESS_FLOWS.md)
  - [ ] `pnpm test:e2e:critical` zielone
  - [ ] Seed danych aktualny (jeśli dotyczy)
- QG‑TECH (docs/06_TECHNICAL_MODULE.md)
  - [ ] Pola/relacje, routing, UoM zgodne z dokumentacją
  - [ ] Kluczowe ścieżki zweryfikowane (E2E lub opis ręcznej weryfikacji)
- QG‑WH (docs/07_WAREHOUSE_AND_SCANNER.md)
  - [ ] Receive/Moves/Split/Merge/Pack zweryfikowane (E2E lub ręcznie)

## Wykonane sprawdzenia

- [ ] `pnpm type-check`
- [ ] `pnpm lint` i `pnpm format:check`
- [ ] `pnpm test:unit`
- [ ] `pnpm test:e2e:critical` (jeśli dotyczy)
- [ ] `pnpm docs:update` (jeśli dotyczy)
- [ ] `pnpm gen-types` (jeśli dotyczy; wymaga Supabase CLI)

## Środowisko i migracje

- Zmiany `.env` (jeśli są):
- Kroki migracji/rollback:

## Ryzyka i wdrożenie

- Ryzyka/regresje:
- Flagi funkcji/feature toggles:
- Monitoring/rollout plan:

---

Uwaga: Niniejszy szablon ma charakter pomocniczy i nie zmienia konfiguracji BMAD. Trzymaj się kroków i bramek z `docs/master_bmad.md`.
