### PR TITLE
Fix BOM creation with invalid status enum

### DIFF
--- a/apps/frontend/app/api/technical/boms/[id]/clone/route.ts
+++ b/apps/frontend/app/api/technical/boms/[id]/clone/route.ts
@@ -87,7 +87,7 @@ export async function POST(
         version: newVersion,
         effective_from,
         effective_to,
-        status: 'draft', // AC-2.10.3: Cloned BOMs default to Draft
+        status: 'Draft', // AC-2.10.3: Cloned BOMs default to Draft
         output_qty: sourceBOM.output_qty,
         output_uom: sourceBOM.output_uom,
         notes: sourceBOM.notes,

--- a/apps/frontend/app/api/technical/boms/timeline/route.ts
+++ b/apps/frontend/app/api/technical/boms/timeline/route.ts
@@ -16,13 +16,13 @@ import { ZodError } from 'zod';
 
 function getStatusColor(status: BOMStatus): string {
   switch (status) {
-    case 'active':
+    case 'Active':
       return 'green';
-    case 'draft':
+    case 'Draft':
       return 'gray';
-    case 'phased_out':
+    case 'Phased Out':
       return 'orange';
-    case 'inactive':
+    case 'Inactive':
       return 'red';
     default:
       return 'gray';

--- a/apps/frontend/components/technical/BOMFormModal.tsx
+++ b/apps/frontend/components/technical/BOMFormModal.tsx
@@ -52,7 +52,7 @@ export function BOMFormModal({ bom, onClose, onSuccess }: BOMFormModalProps) {
         ? bom.effective_to.split('T')[0]
         : new Date(bom.effective_to).toISOString().split('T')[0]
       : '',
-    status: bom?.status || 'draft',
+    status: bom?.status || 'Draft',
     output_qty: bom?.output_qty?.toString() || '1',
     output_uom: bom?.output_uom || '',
     notes: bom?.notes || '',
@@ -335,10 +335,10 @@ export function BOMFormModal({ bom, onClose, onSuccess }: BOMFormModalProps) {
                 <SelectValue placeholder="Select status" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="draft">Draft</SelectItem>
-                <SelectItem value="active">Active</SelectItem>
-                <SelectItem value="phased_out">Phased Out</SelectItem>
-                <SelectItem value="inactive">Inactive</SelectItem>
+                <SelectItem value="Draft">Draft</SelectItem>
+                <SelectItem value="Active">Active</SelectItem>
+                <SelectItem value="Phased Out">Phased Out</SelectItem>
+                <SelectItem value="Inactive">Inactive</SelectItem>
               </SelectContent>
             </Select>
             {errors.status && <p className="text-sm text-red-500">{errors.status}</p>}

--- a/apps/frontend/lib/services/bom-service.ts
+++ b/apps/frontend/lib/services/bom-service.ts
@@ -270,7 +270,7 @@ export async function createBOM(input: CreateBOMInput): Promise<BOM> {
       version: newVersion,
       effective_from,
       effective_to,
-      status: input.status || 'draft',
+      status: input.status || 'Draft',
       output_qty: input.output_qty || 1.0,
       output_uom: input.output_uom,
       notes: input.notes || null,

--- a/apps/frontend/lib/validation/bom-schemas.ts
+++ b/apps/frontend/lib/validation/bom-schemas.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
-// BOM Status enum
-export const BOMStatusEnum = z.enum(['draft', 'active', 'phased_out', 'inactive'])
+// BOM Status enum - must match database enum values exactly
+export const BOMStatusEnum = z.enum(['Draft', 'Active', 'Phased Out', 'Inactive'])
 export type BOMStatus = z.infer<typeof BOMStatusEnum>
 
 // Date string validation (accepts YYYY-MM-DD or full ISO datetime)
@@ -21,7 +21,7 @@ export const CreateBOMSchema = z.object({
   product_id: z.string().uuid('Invalid product ID'),
   effective_from: dateStringSchema.or(z.date()),
   effective_to: dateStringSchema.or(z.date()).optional().nullable(),
-  status: BOMStatusEnum.optional().default('draft'),
+  status: BOMStatusEnum.optional().default('Draft'),
   output_qty: z.number().positive('Output quantity must be positive').optional().default(1.0),
   output_uom: z.string().min(1, 'Unit of measure is required'),
   notes: z.string().optional().nullable()


### PR DESCRIPTION
The PostgreSQL bom_status enum uses capitalized values with spaces ('Draft', 'Active', 'Phased Out', 'Inactive') but the code was using lowercase values ('draft', 'active', 'phased_out', 'inactive').

Updated:
- bom-schemas.ts: BOMStatusEnum values to match DB
- bom-service.ts: default status fallback
- clone/route.ts: cloned BOM default status
- timeline/route.ts: status color mapping
- BOMFormModal.tsx: default status and select options

# Podsumowanie

- Krótki opis celu i kontekstu zmian.

## Typ zmiany

- [ ] feat
- [ ] fix
- [ ] chore
- [ ] docs
- [ ] test

## Powiązane zagadnienia

- Closes #
- Relates to #

## Zakres i wpływ

- Co zostało zmienione (moduły, endpointy, komponenty).
- Potencjalny wpływ na istniejące funkcje i dane.

## Zmiany (skrót)

-
-

## Zrzuty ekranu / wideo (UI)

- Jeśli dotyczy, dołącz materiały poglądowe.

## Jak testować (lokalnie)

```bash
pnpm install
pnpm type-check
pnpm test
# opcjonalnie
pnpm test:e2e:critical
```

## BMAD Quality Gates — Minimal Pass

- QG‑AUDIT (docs/12_NIESPOJNOSCI_FIX_CHECKLIST.md)
  - [ ] P0 zidentyfikowane i rozwiązane lub N/A z uzasadnieniem
- QG‑DB (docs/09_DATABASE_SCHEMA.md)
  - [ ] Migracje dodane i przetestowane
  - [ ] Dokumentacja schematu zaktualizowana
  - [ ] PK/FK/indeksy oraz RLS zgodne z ustaleniami
- QG‑UI (docs/03_APP_GUIDE.md)
  - [ ] Lint i type‑check bez ostrzeżeń
  - [ ] Brak błędów w konsoli przeglądarki
  - [ ] Krytyczne E2E zielone (apps/frontend/e2e/…)
  - [ ] Kontrakt typów API↔UI zgodny
- QG‑PROC (docs/02_BUSINESS_PROCESS_FLOWS.md)
  - [ ] `pnpm test:e2e:critical` zielone
  - [ ] Seed danych aktualny (jeśli dotyczy)
- QG‑TECH (docs/06_TECHNICAL_MODULE.md)
  - [ ] Pola/relacje, routing, UoM zgodne z dokumentacją
  - [ ] Kluczowe ścieżki zweryfikowane (E2E lub opis ręcznej weryfikacji)
- QG‑WH (docs/07_WAREHOUSE_AND_SCANNER.md)
  - [ ] Receive/Moves/Split/Merge/Pack zweryfikowane (E2E lub ręcznie)

## Wykonane sprawdzenia

- [ ] `pnpm type-check`
- [ ] `pnpm lint` i `pnpm format:check`
- [ ] `pnpm test:unit`
- [ ] `pnpm test:e2e:critical` (jeśli dotyczy)
- [ ] `pnpm docs:update` (jeśli dotyczy)
- [ ] `pnpm gen-types` (jeśli dotyczy; wymaga Supabase CLI)

## Środowisko i migracje

- Zmiany `.env` (jeśli są):
- Kroki migracji/rollback:

## Ryzyka i wdrożenie

- Ryzyka/regresje:
- Flagi funkcji/feature toggles:
- Monitoring/rollout plan:

---

Uwaga: Niniejszy szablon ma charakter pomocniczy i nie zmienia konfiguracji BMAD. Trzymaj się kroków i bramek z `docs/master_bmad.md`.
